### PR TITLE
Install LetsEncrypt cert without email address

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -568,7 +568,7 @@ validate_vars_ssl()
 	while [[ -z $SSL_EMAIL ]]
 		do
 		echo -e ""
-		notice "LetsEncrypt requires a valid email address for you. Enter it below"
+		notice "LetsEncrypt email address. Enter it below (or leave blank)."
 		prompt "Enter your email"
 		SSL_EMAIL=$(get_input "")
 		if [[ $SSL_EMAIL = "" ]]

--- a/install.sh
+++ b/install.sh
@@ -564,18 +564,20 @@ validate_vars_ssl()
 			unset SSL_DOMAIN
 		fi
 	done
-	
-	while [[ -z $SSL_EMAIL ]]
-		do
-		echo -e ""
-		notice "LetsEncrypt email address. Enter it below (or leave blank)."
-		prompt "Enter your email"
-		SSL_EMAIL=$(get_input "")
-		if [[ $SSL_EMAIL = "" ]]
-			then
-			unset SSL_EMAIL
-		fi
-	done
+
+# If we're not giving LetsEncrypt an email address, we don't need to validate
+# if email exists.
+#	while [[ -z $SSL_EMAIL ]]
+#		do
+#		echo -e ""
+#		notice "LetsEncrypt email address. Enter it below (or leave blank)."
+#		prompt "Enter your email"
+#		SSL_EMAIL=$(get_input "")
+#		if [[ $SSL_EMAIL = "" ]]
+#			then
+#			unset SSL_EMAIL
+#		fi
+#	done
 }
 
 
@@ -989,9 +991,11 @@ install_ssl()
 		info "Installing and configuring LetsEncrypt...this can take a few minutes"
 		if [[ $VERBOSE = "true" ]]
 			then
-			resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --email ${SSL_EMAIL} --redirect --hsts --apache 2>&1 | tee /dev/tty)
+      if [[ -z ${SSL_EMAIL} ]]
+         then
+         resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --email ${SSL_EMAIL} --redirect --hsts --apache 2>&1 | tee /dev/tty)
 		else
-			resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --email ${SSL_EMAIL} --redirect --hsts --apache 2>&1)
+			resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --register-unsafely-without-email --redirect --hsts --apache 2>&1)
 		fi
 		if [[ $resp =~ Failed ]]
 			then

--- a/install.sh
+++ b/install.sh
@@ -996,12 +996,14 @@ install_ssl()
          resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --email ${SSL_EMAIL} --redirect --hsts --apache 2>&1 | tee /dev/tty)
       else
          resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --register-unsafely-without-email --redirect --hsts --apache 2>&1 | tee /dev/tty)
+      fi
 		else
         if [[ -z ${SSL_EMAIL} ]]
            then
            resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --email ${SSL_EMAIL} --redirect --hsts --apache 2>&1)
         else
            resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --register-unsafely-without-email --redirect --hsts --apache 2>&1)
+        fi
 		fi
 		if [[ $resp =~ Failed ]]
 			then

--- a/install.sh
+++ b/install.sh
@@ -994,8 +994,14 @@ install_ssl()
       if [[ -z ${SSL_EMAIL} ]]
          then
          resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --email ${SSL_EMAIL} --redirect --hsts --apache 2>&1 | tee /dev/tty)
+      else
+         resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --register-unsafely-without-email --redirect --hsts --apache 2>&1 | tee /dev/tty)
 		else
-			resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --register-unsafely-without-email --redirect --hsts --apache 2>&1)
+        if [[ -z ${SSL_EMAIL} ]]
+           then
+           resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --email ${SSL_EMAIL} --redirect --hsts --apache 2>&1)
+        else
+           resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --register-unsafely-without-email --redirect --hsts --apache 2>&1)
 		fi
 		if [[ $resp =~ Failed ]]
 			then

--- a/install.sh
+++ b/install.sh
@@ -990,20 +990,10 @@ install_ssl()
 		sys_cmd "chmod a+x /usr/local/sbin/certbot-auto"
 		info "Installing and configuring LetsEncrypt...this can take a few minutes"
 		if [[ $VERBOSE = "true" ]]
-			then
-      if [[ -z ${SSL_EMAIL} ]]
-         then
-         resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --email ${SSL_EMAIL} --redirect --hsts --apache 2>&1 | tee /dev/tty)
-      else
-         resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --register-unsafely-without-email --redirect --hsts --apache 2>&1 | tee /dev/tty)
-      fi
+      then
+      resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --register-unsafely-without-email --redirect --hsts --apache 2>&1 | tee /dev/tty)
 		else
-        if [[ -z ${SSL_EMAIL} ]]
-           then
-           resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --email ${SSL_EMAIL} --redirect --hsts --apache 2>&1)
-        else
-           resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --register-unsafely-without-email --redirect --hsts --apache 2>&1)
-        fi
+      resp=$(certbot-auto -n -d ${SSL_DOMAIN} --agree-tos --register-unsafely-without-email --redirect --hsts --apache 2>&1)
 		fi
 		if [[ $resp =~ Failed ]]
 			then


### PR DESCRIPTION
LetsEncrypt can install certs without requiring an email address (`--register-unsafely-without-email` option); this will streamline the installation process a bit more.